### PR TITLE
Create dropdown for menu item with children

### DIFF
--- a/stylus/main.css
+++ b/stylus/main.css
@@ -80,6 +80,16 @@ body {
   margin: 1rem;
   font-weight: bold;
 }
+.sub-menu {
+  flex-direction: column;
+  visibility: hidden;
+}
+.sub-menu li {
+  margin-left: 0;
+}
+.menu-item-has-children:hover .sub-menu {
+  visibility: visible;
+}
 .wt_banner {
   width: 100%;
   height: 100vh;

--- a/stylus/require/layouts.styl
+++ b/stylus/require/layouts.styl
@@ -46,6 +46,18 @@ body
     margin 1rem
     font-weight bold
 
+// Dropdown nav
+.sub-menu
+    flex-direction column
+    visibility hidden
+
+.sub-menu li
+    margin-left 0 // Cancel spacing from .header li
+
+.menu-item-has-children:hover .sub-menu
+    visibility visible
+
+
 /* NO BROWSER SUPPORT
 // White text if over a banner
 .header:has(+ .wt_banner) a


### PR DESCRIPTION
- Apply styles to WP default nav classes .menu-item-has-children and
.sub-menu
- Change flex direction of .sub-menu to column
- .sub-menu has visibility:hidden; and changes to visibility:visible
when hovering .menu-item-has-children

Fixes #2 