### PR TITLE
Reconciled projects post-type and page slugs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -455,9 +455,9 @@ add_shortcode('html5_shortcode_demo_2', 'html5_shortcode_demo_2'); // Place [htm
 // Projects, aka Initiatives
 function create_post_type_projects()
 {
-    register_taxonomy_for_object_type('category', 'projects'); 
-    register_taxonomy_for_object_type('post_tag', 'projects');
-    register_post_type('projects',
+    register_taxonomy_for_object_type('category', 'project_posts'); 
+    register_taxonomy_for_object_type('post_tag', 'project_posts');
+    register_post_type('project_posts',
         array(
         'labels' => array(
             'name' => __('Projects', 'project'), 


### PR DESCRIPTION
changed projects post-type slug to from **projects** to **project_posts** to allow for wikitongues.org to exist