### PR TITLE
[WIP] Fix image display

### DIFF
--- a/stylus/main.css
+++ b/stylus/main.css
@@ -198,6 +198,13 @@ section:nth-child(even) .wt_section-message {
   column-gap: 10rem;
   row-gap: 10rem;
 }
+.wt_member {
+  display: flex;
+}
+.wt_member > * {
+  flex: 1;
+  margin: 1rem;
+}
 .footer {
   background-color: #0d232f;
   color: #fff;

--- a/stylus/main.css
+++ b/stylus/main.css
@@ -163,6 +163,11 @@ section:nth-child(even) .wt_section-message {
   padding: 2rem;
   background-color: #fff;
   border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+.wt_featured-item > a {
+  flex-basis: 10rem;
 }
 .wt_page-intro {
   max-width: 60rem;

--- a/stylus/require/layouts.styl
+++ b/stylus/require/layouts.styl
@@ -158,6 +158,17 @@ section:nth-child(even) .wt_section-message
     padding 2rem
     background-color white
     border-radius 1rem
+    // Featured item content flexbox
+    display flex
+    flex-direction column
+
+// Each featured item has three children:
+// 1. A link to youtube with a background image
+// 2. An h2 title
+// 3. A paragraph with intro text
+
+.wt_featured-item > a
+    flex-basis 10rem
 
 /*------------------------------------*\
     PAGE INTRO

--- a/stylus/require/layouts.styl
+++ b/stylus/require/layouts.styl
@@ -209,6 +209,13 @@ section:nth-child(even) .wt_section-message
     column-gap 10rem
     row-gap 10rem
 
+.wt_member
+    display flex
+
+.wt_member > *
+    flex 1
+    margin 1rem
+
 /*------------------------------------*\
     FOOTER
     footer.php


### PR DESCRIPTION
# Member images

- Create flexbox for wt_member
- Two flex items: the picture and the member info. Each has flex 1
- Layout has background-size 0 0 no repeat hardcoded. This crops the
member images

Fixes #14