### PR TITLE
Partners template

### DIFF
--- a/template-partners.php
+++ b/template-partners.php
@@ -95,11 +95,7 @@ function expandPartner (i, partnersPerRow) {
 				profileInRow.classList.add('row-expanded');
 			}
 
-			profile.scrollIntoView({
-				behavior: 'smooth',
-				block: 'center',
-				inline: 'start'
-			});
+			window.scroll(0, profile.offsetTop - window.innerHeight / 2 + profile.offsetHeight / 2);
 		}
 
 		// show carat attached to profile panel pointing to logo in grid


### PR DESCRIPTION
I did not see the behavior from your screenshots, for me it centered the content when I clicked an icon on the second row while the profile was expanded for an icon on the first row.

I changed the function call that does the scrolling. It works for me in Firefox, Chrome, and Safari (albeit without smooth scrolling). Please let me know if the results are any better for you.